### PR TITLE
エントリーがない場合でもなにかしらメッセージを返す

### DIFF
--- a/command.js
+++ b/command.js
@@ -39,6 +39,8 @@ function doPost(e) {
   const index = { DATE: 0, NAME: 1, TITLE: 2, STATUS: 3 };
   const messages = {
     no_entry: "エントリーはありません",
+    reset_order: "すべてのエントリーを順番を決めてない状態に戻しました",
+    full_entry: "満席です",
   }
 
   // なければ sheet を作る
@@ -76,7 +78,7 @@ function doPost(e) {
           return createPublicTextOutput(payload);
         }
       }
-      return ContentService.createTextOutput("満席です。");
+      return ContentService.createTextOutput(messages.full_entry);
     }
     case 'remove': {
       const entryId = argText.slice(idx + 1, argText.length).trim();
@@ -233,7 +235,7 @@ function doPost(e) {
         1,
       ).setValues([...values]);
 
-      return ContentService.createTextOutput("すべてのエントリーを順番決めてない扱いにしました");
+      return ContentService.createTextOutput(messages.reset_order);
     }
     default:
       return ContentService.createTextOutput(cmd + "\n" + help);

--- a/command.js
+++ b/command.js
@@ -37,6 +37,9 @@ function doPost(e) {
   const maxRowSize = 100; // TODO: さぽって 100 行に限定してる
   const status = { ORDERED: 'ordered', UNORDERED: 'unordered', REMOVED: 'removed' };
   const index = { DATE: 0, NAME: 1, TITLE: 2, STATUS: 3 };
+  const messages = {
+    no_entry: "エントリーはありません",
+  }
 
   // なければ sheet を作る
   const sheet = function(name) {
@@ -117,7 +120,7 @@ function doPost(e) {
       }
 
       if (entryCount === 0) {
-        return ContentService.createTextOutput('エントリーはありません');
+        return ContentService.createTextOutput(messages.no_entry);
       } else {
         return ContentService.createTextOutput(text);
       }
@@ -144,7 +147,7 @@ function doPost(e) {
       }
 
       if (entryCount === 0) {
-        return ContentService.createTextOutput('エントリーはありません');
+        return ContentService.createTextOutput(messages.no_entry);
       } else {
         const payload = createMessagePayload(text);
 
@@ -169,6 +172,8 @@ function doPost(e) {
         allText += `- ${badge} ${entry[index.TITLE]} by ${entry[index.NAME]}, entryId: ${startRowNum + i}\n`;
       }
 
+      if (!allText) allText = messages.no_entry;
+
       return ContentService.createTextOutput(allText);
     }
     case 'shuffle': {
@@ -185,6 +190,10 @@ function doPost(e) {
 
         const entry = entries[i];
         container.push(entry);
+      }
+
+      if (container.length === 0) {
+        return createPublicTextOutput(createMessagePayload(messages.no_entry));
       }
 
       // 並び替え対象としたものに印をつける

--- a/command.js
+++ b/command.js
@@ -109,6 +109,7 @@ function doPost(e) {
         if (!entries[i][index.DATE]) break;
 
         if (entries[i][index.NAME] !== userName) continue;
+        if (entries[i][index.STATUS] === status.REMOVED) continue;
 
         const title = entries[i][index.TITLE];
         text += `- ${title}, entryId: ${startRowNum + i}\n`;


### PR DESCRIPTION
エントリーが元々ない、もしくは、削除してエントリーがない場合に、エントリーがないことを示すメッセージを出力するようにした。以前はレスポンスが何もなかった。

併せて、`my` コマンド時に削除済みエントリーを出力していた問題を修正した。

ref: 
- https://github.com/kanazawarb/kzlt/issues/5