### PR TITLE
発表済みとそうでないものを区別できるようにする

### DIFF
--- a/command.js
+++ b/command.js
@@ -144,6 +144,7 @@ function doPost(e) {
       for (let i = 0; i < maxRowSize; i++) {
         if (!entries[i][index.DATE]) break;
         if (entries[i][index.STATUS] !== status.UNORDERED) continue;
+        if (entries[i][index.STATUS] !== status.DELIMITED) continue;
 
         const name = entries[i][index.NAME];
         const title = entries[i][index.TITLE];
@@ -173,7 +174,7 @@ function doPost(e) {
         if (entries[i][index.STATUS] === status.REMOVED) continue
 
         const entry = entries[i];
-        const badge = entry[index.STATUS] === status.ORDERED ? '[done]' : '';
+        const badge = (entry[index.STATUS] === status.ORDERED || entry[index.STATUS] === status.DELIMITED) ? '[done]' : '';
         allText += `- ${badge} ${entry[index.TITLE]} by ${entry[index.NAME]}, entryId: ${startRowNum + i}\n`;
       }
 
@@ -202,7 +203,19 @@ function doPost(e) {
       }
 
       // 並び替え対象としたものに印をつける
-      const statuses = container.map((v) => v[index.STATUS] === status.REMOVED ? [status.REMOVED] : [status.ORDERED]);
+      const statuses = container.map((v) => {
+        switch (v[index.STATUS]) {
+          case status.REMOVED: {
+            return [status.REMOVED];
+          }
+          case status.DELIMITED: {
+            return [status.DELIMITED];
+          }
+          default: {
+            return [status.ORDERED];
+          }
+        }
+      });
       sheet.getRange(
         startRowNum,
         5,
@@ -300,6 +313,7 @@ function makeMarkdown(container, status, index) {
     const ary = container[num];
 
     if (ary[index.STATUS] === status.REMOVED) continue;
+    if (ary[index.STATUS] === status.DELIMITED) continue;
 
     mdTable += `| ${ary[index.TITLE]} | | | ${ary[index.NAME]} |\n`;
     mdList += `- ${ary[index.TITLE]} by ${ary[index.NAME]}\n`;

--- a/command.js
+++ b/command.js
@@ -35,7 +35,7 @@ function doPost(e) {
   const startRowNum = 2;
   const startColNum = 2;
   const maxRowSize = 100; // TODO: さぽって 100 行に限定してる
-  const status = { ORDERED: 'ordered', UNORDERED: 'unordered', REMOVED: 'removed' };
+  const status = { ORDERED: 'ordered', UNORDERED: 'unordered', REMOVED: 'removed', FINISHED: 'finished' };
   const index = { DATE: 0, NAME: 1, TITLE: 2, STATUS: 3 };
   const messages = {
     no_entry: "エントリーはありません",
@@ -50,7 +50,7 @@ function doPost(e) {
   }(sheetName);
 
   switch (cmd) {
-    case 'entry': {
+    case 'entry': { // エントリする
       const current = new Date().toLocaleString();
       const userName = e.parameter.user_name;
       const title = argText.slice(idx + 1, argText.length).trim();
@@ -80,7 +80,7 @@ function doPost(e) {
       }
       return ContentService.createTextOutput(messages.full_entry);
     }
-    case 'remove': {
+    case 'remove': { // 番号指定でエントリを削除扱いにする
       const entryId = argText.slice(idx + 1, argText.length).trim();
       if (Number(entryId) === 0 || Number.isNaN === Number(entryId) || typeof (Number(entryId)) !== 'number') {
         return ContentService.createTextOutput('entry 時に返ってきた entryId を指定してください /kzlt remove 1');
@@ -99,7 +99,7 @@ function doPost(e) {
       );
       return createPublicTextOutput(payload);
     }
-    case 'my': {
+    case 'my': { // 自分がエントリしたものを出力する
       const entries = sheet.getRange(
         startRowNum,
         startColNum,
@@ -128,7 +128,7 @@ function doPost(e) {
       }
     }
 
-    case 'list': {
+    case 'list': { // shuffle されていないエントリを出力する
       const entries = sheet.getRange(
         startRowNum,
         startColNum,
@@ -156,7 +156,7 @@ function doPost(e) {
         return createPublicTextOutput(payload);
       }
     }
-    case 'all': {
+    case 'all': { // 削除扱いのエントリ以外すべてを出力する
       const entries = sheet.getRange(
         startRowNum,
         startColNum,
@@ -178,7 +178,7 @@ function doPost(e) {
 
       return ContentService.createTextOutput(allText);
     }
-    case 'shuffle': {
+    case 'shuffle': { // shuffle されていないエントリをシャッフルする
       const entries = sheet.getRange(
         startRowNum,
         startColNum,
@@ -213,7 +213,7 @@ function doPost(e) {
       const payload = createMessagePayload(mdText);
       return createPublicTextOutput(payload);
     }
-    case 'reset': {
+    case 'reset': { // すでにシャッフルされたエントリの状態をシャッフルされていない状態に戻す
       const entries = sheet.getRange(
         startRowNum,
         startColNum,

--- a/command.js
+++ b/command.js
@@ -230,7 +230,19 @@ function doPost(e) {
 
         container.push(entries[i]);
       }
-      const values = container.map((v) => v[index.STATUS] === status.REMOVED ? [status.REMOVED] : [status.UNORDERED]);
+      const values = container.map((v) => {
+        switch (v[index.STATUS]) {
+          case status.REMOVED: {
+            return [status.REMOVED];
+          }
+          case status.DELIMITED: {
+            return [status.DELIMITED];
+          }
+          default: {
+            return [status.UNORDERED];
+          }
+        }
+      });
       sheet.getRange(
         startRowNum,
         5,


### PR DESCRIPTION
`/kzlt shuffle` して順番を決めた後でも `/kzlt entry <title>` でエントリを追加できたが、 実施後/実施前のエントリの区別がなかった。これを区別するため、以下のように手をいれた。

1. コマンド `/kzlt delimit` を追加し、shuffle 後のエントリを状態: delimited に変更するようにした
2. `/kzlt reset` 時に delimited を対象外とした
3. `/kzlt list` 時に delimited を対象外とした
4. `/kzlt all` 時に delimited を `[done]` 扱いとした
5. `/kzlt shuffle` 時に delimited を対象外とした