### PR TITLE
抽出するエントリの状態の誤りを修正する

### DIFF
--- a/command.js
+++ b/command.js
@@ -144,7 +144,6 @@ function doPost(e) {
       for (let i = 0; i < maxRowSize; i++) {
         if (!entries[i][index.DATE]) break;
         if (entries[i][index.STATUS] !== status.UNORDERED) continue;
-        if (entries[i][index.STATUS] !== status.DELIMITED) continue;
 
         const name = entries[i][index.NAME];
         const title = entries[i][index.TITLE];


### PR DESCRIPTION
`/kzlt list` にて、抽出対象のエントリの状態判定が誤っていたので修正する。