### PR TITLE
delimit コマンドの不具合を修正する

### DIFF
--- a/command.js
+++ b/command.js
@@ -283,7 +283,8 @@ function doPost(e) {
         ).setValue(status.DELIMITED)
       }
 
-      return ContentService.createTextOutput(messages.delimit_time);
+      const payload = createMessagePayload(messages.delimit_time);
+      return createPublicTextOutput(payload);
     }
     default:
       return ContentService.createTextOutput(cmd + "\n" + help);

--- a/command.js
+++ b/command.js
@@ -280,7 +280,7 @@ function doPost(e) {
           startRowNum + i,
           5,
           1,
-        ).setValues(status.DELIMITED)
+        ).setValue(status.DELIMITED)
       }
 
       return ContentService.createTextOutput(messages.delimit_time);


### PR DESCRIPTION
以下の対応を含めた
- セルに書き込む関数名の誤りを修正した setValues -> setValue
- 実行後のメッセージは、全員に表示するように修正した。認識をとれるため。